### PR TITLE
fix aodh api service default port

### DIFF
--- a/openstack-aodh-api.service
+++ b/openstack-aodh-api.service
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 User=aodh
-ExecStart=/usr/bin/aodh-api -- --logfile /var/log/aodh/api.log
+ExecStart=/usr/bin/aodh-api --port=8042 -- --logfile /var/log/aodh/api.log
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
User had to change the default port when using aodh-api.
Related to: https://bugs.launchpad.net/aodh/+bug/1642798
This change fix the port issue.